### PR TITLE
feat: Support `site` and `region_code` arguments

### DIFF
--- a/builder/ncloud/builder.go
+++ b/builder/ncloud/builder.go
@@ -2,6 +2,7 @@ package ncloud
 
 import (
 	"context"
+	"os"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
 	"github.com/hashicorp/hcl/v2/hcldec"
@@ -36,6 +37,13 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	config := Config{
 		AccessKey: b.config.AccessKey,
 		SecretKey: b.config.SecretKey,
+	}
+
+	switch b.config.Site {
+	case "gov":
+		os.Setenv("NCLOUD_API_GW", "https://ncloud.apigw.gov-ntruss.com")
+	case "fin":
+		os.Setenv("NCLOUD_API_GW", "https://fin-ncloud.apigw.fin-ntruss.com")
 	}
 
 	conn, err := config.Client()

--- a/builder/ncloud/config.go
+++ b/builder/ncloud/config.go
@@ -54,7 +54,9 @@ type Config struct {
 	BlockStorageSize int `mapstructure:"block_storage_size" required:"false"`
 	// Name of the region where you want to create an image.
 	// (default: Korea)
-	Region     string `mapstructure:"region" required:"false"`
+	Region string `mapstructure:"region" required:"false"`
+	// Code of the region
+	// (default: KR) (fin default: FKR)
 	RegionCode string `mapstructure:"region_code" required:"false"`
 	// Deprecated
 	AccessControlGroupConfigurationNo string `mapstructure:"access_control_group_configuration_no" required:"false"`

--- a/builder/ncloud/config.go
+++ b/builder/ncloud/config.go
@@ -70,6 +70,9 @@ type Config struct {
 	// The ID of the VPC where you want to place the Server Instance. If this field is left blank, Packer will try to get the VPC ID from the `subnet_no`.
 	// (You are required to least one between two parameters if u want using VPC environment: `vpc_no` or `subnet_no`)
 	VpcNo string `mapstructure:"vpc_no" required:"false"`
+	// The ncloud site (Default: public)
+	// available site: public(`www.ncloud.com`), gov(`www.gov-ncloud.com`) and fin(`www.fin-ncloud.com`)
+	Site string `mapstructure:"site" required:"false"`
 
 	Comm communicator.Config `mapstructure:",squash"`
 	ctx  *interpolate.Context

--- a/builder/ncloud/config.hcl2spec.go
+++ b/builder/ncloud/config.hcl2spec.go
@@ -35,6 +35,7 @@ type FlatConfig struct {
 	SupportVPC                        *bool             `mapstructure:"support_vpc" required:"false" cty:"support_vpc" hcl:"support_vpc"`
 	SubnetNo                          *string           `mapstructure:"subnet_no" required:"false" cty:"subnet_no" hcl:"subnet_no"`
 	VpcNo                             *string           `mapstructure:"vpc_no" required:"false" cty:"vpc_no" hcl:"vpc_no"`
+	Site                              *string           `mapstructure:"site" required:"false" cty:"site" hcl:"site"`
 	Type                              *string           `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect                *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                           *string           `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -123,6 +124,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"support_vpc":                           &hcldec.AttrSpec{Name: "support_vpc", Type: cty.Bool, Required: false},
 		"subnet_no":                             &hcldec.AttrSpec{Name: "subnet_no", Type: cty.String, Required: false},
 		"vpc_no":                                &hcldec.AttrSpec{Name: "vpc_no", Type: cty.String, Required: false},
+		"site":                                  &hcldec.AttrSpec{Name: "site", Type: cty.String, Required: false},
 		"communicator":                          &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":               &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                              &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},

--- a/builder/ncloud/step_validate_template.go
+++ b/builder/ncloud/step_validate_template.go
@@ -16,7 +16,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-//StepValidateTemplate : struct for Validation a template
+// StepValidateTemplate : struct for Validation a template
 type StepValidateTemplate struct {
 	Conn                      *NcloudAPIClient
 	Validate                  func() error
@@ -97,7 +97,7 @@ func (s *StepValidateTemplate) getZoneNo() error {
 
 // getZoneCode : get zoneCode
 func (s *StepValidateTemplate) getZoneCode() error {
-	if s.Config.Region == "" {
+	if s.Config.Region == "" && s.Config.RegionCode == "" {
 		return nil
 	}
 
@@ -110,6 +110,12 @@ func (s *StepValidateTemplate) getZoneCode() error {
 		if strings.EqualFold(*region.RegionName, s.Config.Region) {
 			s.regionCode = *region.RegionCode
 			s.Config.RegionCode = *region.RegionCode
+			break
+		}
+		if strings.EqualFold(*region.RegionCode, s.Config.RegionCode) {
+			s.regionCode = *region.RegionCode
+			s.Config.RegionCode = *region.RegionCode
+			break
 		}
 	}
 

--- a/docs-partials/builder/ncloud/Config-not-required.mdx
+++ b/docs-partials/builder/ncloud/Config-not-required.mdx
@@ -27,7 +27,8 @@
 - `region` (string) - Name of the region where you want to create an image.
   (default: Korea)
 
-- `region_code` (string) - Region Code
+- `region_code` (string) - Code of the region
+  (default: KR) (fin default: FKR)
 
 - `access_control_group_configuration_no` (string) - Deprecated
 

--- a/docs-partials/builder/ncloud/Config-not-required.mdx
+++ b/docs-partials/builder/ncloud/Config-not-required.mdx
@@ -44,4 +44,7 @@
 - `vpc_no` (string) - The ID of the VPC where you want to place the Server Instance. If this field is left blank, Packer will try to get the VPC ID from the `subnet_no`.
   (You are required to least one between two parameters if u want using VPC environment: `vpc_no` or `subnet_no`)
 
+- `site` (string) - The ncloud site (Default: public)
+  available site: public(`www.ncloud.com`), gov(`www.gov-ncloud.com`) and fin(`www.fin-ncloud.com`)
+
 <!-- End of code generated from the comments of the Config struct in builder/ncloud/config.go; -->

--- a/docs/builders/ncloud.mdx
+++ b/docs/builders/ncloud.mdx
@@ -73,6 +73,11 @@ Platform](https://www.ncloud.com/).
   (default: Korea)
   - values: Korea / US-West / HongKong / Singapore / Japan / Germany
 
+- `site` (string) - The ncloud site. Available sites are
+  public(`www.ncloud.com`), gov(`www.gov-ncloud.com`) and fin(`www.fin-ncloud.com`)
+  (default: public)
+  - values: public / gov / fin
+
 ## Basic Example
 
 Here is a basic example for windows server.

--- a/docs/builders/ncloud.mdx
+++ b/docs/builders/ncloud.mdx
@@ -72,6 +72,12 @@ Platform](https://www.ncloud.com/).
 - `region` (string) - Name of the region where you want to create an image.
   (default: Korea)
   - values: Korea / US-West / HongKong / Singapore / Japan / Germany
+  (`region` or `region code` must be set)
+
+- `region_code` (string) - Code of the region where you want to create an image.
+  (default: KR)
+  - values: KR / US / HK / SG / JP / GE
+  (`region` or `region code` must be set)
 
 - `site` (string) - The ncloud site. Available sites are
   public(`www.ncloud.com`), gov(`www.gov-ncloud.com`) and fin(`www.fin-ncloud.com`)


### PR DESCRIPTION
Hello,
I'm a terraform/packer provider developer for NCloud.

To make things easier for users, It introduced two packer arguments.

Provider's `site` argument has been added. The'site' option in [ncloud-sdk-go-v2](https://github.com/NaverCloudPlatform/ncloud-sdk-go-v2) is used to set the destination site API gateway address.

Additionally, the `region-code` parameter has been around for a while but has never been used. Users can use region code rather than region.