### PR TITLE
.gitignore: ignore crash.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ main
 dist/*
 packer-plugin-ncloud
 .docs
+crash.log


### PR DESCRIPTION
The crash.log file is an artifact from testing, and should not be tracked by Git.