### PR TITLE
fix: resolve error when using member_server_image_no config

### DIFF
--- a/builder/ncloud/step_validate_template.go
+++ b/builder/ncloud/step_validate_template.go
@@ -162,7 +162,7 @@ func (s *StepValidateTemplate) validateMemberServerImage(fnGetServerImageList fu
 
 		if *image.MemberServerImageNo == s.Config.MemberServerImageNo {
 			isExistMemberServerImageNo = true
-			if s.Config.ServerProductCode == "" {
+			if s.Config.ServerProductCode == "" && !s.Config.SupportVPC {
 				s.Config.ServerProductCode = *image.OriginalServerProductCode
 				s.Say("server_product_code for member server image '" + *image.OriginalServerProductCode + "' is configured automatically")
 			}
@@ -203,11 +203,11 @@ func (s *StepValidateTemplate) getVpcMemberServerImageList() ([]*server.MemberSe
 	var results []*server.MemberServerImage
 	for _, r := range memberServerImageList.MemberServerImageInstanceList {
 		results = append(results, &server.MemberServerImage{
-			MemberServerImageNo:          r.MemberServerImageInstanceNo,
-			MemberServerImageName:        r.MemberServerImageName,
-			MemberServerImageDescription: r.MemberServerImageDescription,
-			OriginalServerInstanceNo:     r.OriginalServerInstanceNo,
-			OriginalServerProductCode:    r.OriginalServerImageProductCode,
+			MemberServerImageNo:            r.MemberServerImageInstanceNo,
+			MemberServerImageName:          r.MemberServerImageName,
+			MemberServerImageDescription:   r.MemberServerImageDescription,
+			OriginalServerInstanceNo:       r.OriginalServerInstanceNo,
+			OriginalServerImageProductCode: r.OriginalServerImageProductCode,
 		})
 	}
 
@@ -469,7 +469,11 @@ func (s *StepValidateTemplate) getFirstPublicSubnet() (*vpc.Subnet, error) {
 	}
 
 	if resp != nil && *resp.TotalRows > 0 {
-		return resp.SubnetList[0], nil
+		for _, subnet := range resp.SubnetList {
+			if *subnet.UsageType.Code == "GEN" {
+				return subnet, nil
+			}
+		}
 	}
 
 	return nil, fmt.Errorf("could not found public subnet in `vpc_no` [%s]", s.Config.VpcNo)
@@ -482,7 +486,7 @@ func (s *StepValidateTemplate) validateTemplate() error {
 		return err
 	}
 
-	// Validate member_server_image_no and member_server_image_no
+	// Validate member_server_image_no and Get ServerProductCode or ServerImageProductCode
 	if err := s.validateMemberServerImage(s.getMemberServerImageList); err != nil {
 		return err
 	}

--- a/builder/ncloud/step_validate_template.go
+++ b/builder/ncloud/step_validate_template.go
@@ -162,11 +162,14 @@ func (s *StepValidateTemplate) validateMemberServerImage(fnGetServerImageList fu
 
 		if *image.MemberServerImageNo == s.Config.MemberServerImageNo {
 			isExistMemberServerImageNo = true
-			if s.Config.ServerProductCode == "" && !s.Config.SupportVPC {
+			// OriginalServerProductCode value : Classic exist. VPC not exist.
+			if s.Config.ServerProductCode == "" && image.OriginalServerProductCode != nil {
 				s.Config.ServerProductCode = *image.OriginalServerProductCode
 				s.Say("server_product_code for member server image '" + *image.OriginalServerProductCode + "' is configured automatically")
 			}
-			s.Config.ServerImageProductCode = *image.OriginalServerImageProductCode
+			if image.OriginalServerImageProductCode != nil {
+				s.Config.ServerImageProductCode = *image.OriginalServerImageProductCode
+			}
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/packer-plugin-ncloud
 go 1.18
 
 require (
-	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.7
+	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.5
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/packer-plugin-sdk v0.4.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6/go.mod h1:nu
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg38RRsjT5y8=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.7 h1:Kpnbe19WkzVPpLLdAus4LkpNJ+pzLpfAViOUuvPcCqA=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.7/go.mod h1:P+3VS0ETiQPyWOx3vB/oeC8J3qd7jnVZLYAFwWgGRt8=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.5 h1:d2KDgwBfNSlGRTpcSn5Tzw7yY56m0bPCwaesYaN3QL0=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.5/go.mod h1:sDa6EITv6z/l6+d4VJk4OiRZnXuO0uG2Cm30qtqF4TU=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
## Description

- There is a panic issue when creating an image with `member_server_image_no` config set.

V1.0.4 panic log
```
Build 'ncloud.test-tomcat' errored after 236 milliseconds 750 microseconds: unexpected EOF

==> Wait completed after 236 milliseconds 829 microseconds

==> Some builds didn't complete successfully and had errors:
--> ncloud.test-tomcat: unexpected EOF

==> Builds finished but no artifacts were created.
2023/06/21 19:19:30 packer-plugin-ncloud_v1.0.4_x5.0_darwin_arm64 plugin: panic: runtime error: invalid memory address or nil pointer dereference
2023/06/21 19:19:30 packer-plugin-ncloud_v1.0.4_x5.0_darwin_arm64 plugin: [signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104d10de4]
2023/06/21 19:19:30 packer-plugin-ncloud_v1.0.4_x5.0_darwin_arm64 plugin: github.com/hashicorp/packer-plugin-ncloud/builder/ncloud.(*StepValidateTemplate).validateMemberServerImage(0x140004da000, 0x14000556010)
2023/06/21 19:19:30 packer-plugin-ncloud_v1.0.4_x5.0_darwin_arm64 plugin: 	github.com/hashicorp/packer-plugin-ncloud/builder/ncloud/step_validate_template.go:160 +0x1e4
```

Update panic log to V1.1.0
```
==> Builds finished but no artifacts were created.
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: panic: runtime error: invalid memory address or nil pointer dereference
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: [signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104db0fbc]
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin:
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: goroutine 15 [running]:
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: github.com/hashicorp/packer-plugin-ncloud/builder/ncloud.(*StepValidateTemplate).validateMemberServerImage(0x14000370780, 0x140002ea120?)
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: 	github.com/hashicorp/packer-plugin-ncloud/builder/ncloud/step_validate_template.go:169 +0x19c
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: github.com/hashicorp/packer-plugin-ncloud/builder/ncloud.(*StepValidateTemplate).validateTemplate(0x14000370780)
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: 	github.com/hashicorp/packer-plugin-ncloud/builder/ncloud/step_validate_template.go:486 +0x3c
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: github.com/hashicorp/packer-plugin-ncloud/builder/ncloud.(*StepValidateTemplate).Run(0x14000370780, {0x0?, 0x5000?}, {0x1053908e0, 0x140008e0480})
2023/07/08 22:05:27 packer-plugin-ncloud_v1.1.0_x5.0_darwin_arm64 plugin: 	github.com/hashicorp/packer-plugin-ncloud/builder/ncloud/step_validate_template.go:509 +0x50
``` 

- it fixes by not to reference OriginalServerProductCode(=exists only in Classic API response field) if `support_vpc=true`
