### PR TITLE
fix: Error when copying a server image with added storage

### DIFF
--- a/builder/ncloud/step_delete_block_storage_instance.go
+++ b/builder/ncloud/step_delete_block_storage_instance.go
@@ -138,10 +138,6 @@ func (s *StepDeleteBlockStorage) deleteVpcBlockStorage(serverInstanceNo string) 
 }
 
 func (s *StepDeleteBlockStorage) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	if s.Config.BlockStorageSize == 0 {
-		return processStepResult(nil, s.Error, state)
-	}
-
 	s.Say("Delete Block Storage Instance")
 
 	var serverInstanceNo = state.Get("instance_no").(string)

--- a/builder/ncloud/step_delete_block_storage_instance.go
+++ b/builder/ncloud/step_delete_block_storage_instance.go
@@ -138,6 +138,10 @@ func (s *StepDeleteBlockStorage) deleteVpcBlockStorage(serverInstanceNo string) 
 }
 
 func (s *StepDeleteBlockStorage) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	if s.Config.BlockStorageSize == 0 && s.Config.MemberServerImageNo == "" {
+		return processStepResult(nil, s.Error, state)
+	}
+
 	s.Say("Delete Block Storage Instance")
 
 	var serverInstanceNo = state.Get("instance_no").(string)


### PR DESCRIPTION
### Description
- Error occurred when copying the original server image with added storage to the packer
  - Cause
    - When returning a server, an error occurs if the added storage is not deleted first.
    - Currently deleting storage is only done when adding storage with the `block_storage_size` setting in the config
    - If there is storage added to the original server image, an error occurs because the storage is not deleted.
- Minor, but fixes logs that output pointer addresses

### Resolve
- Change to delete additional storage first before returning the server regardless of the setting.

### Error output
```
==> ncloud.test-tomcat: Terminate Server Instance
==> ncloud.test-tomcat: Status: 400 Bad Request, Body: {
==> ncloud.test-tomcat:   "responseError": {
==> ncloud.test-tomcat:     "returnCode": "1101040",
==> ncloud.test-tomcat:     "returnMessage": "Please return the added storage and try again."
==> ncloud.test-tomcat:   }
==> ncloud.test-tomcat: }
```

### Steps to Reproduce
1) Create a server
2) Use the console to attach additional storage
3) Create a server image from the console
4) Perform image copy operation with console-created server image as a packer
```
xxxxx.pkr.hcl FILE
ex) member_server_image_no = "xxxxxxxxx"
```