### PR TITLE
chore: Fix logs that output pointer addresses and cause lint errors

### DIFF
--- a/builder/ncloud/step_create_access_control_group.go
+++ b/builder/ncloud/step_create_access_control_group.go
@@ -165,7 +165,7 @@ func (s *StepCreateAccessControlGroup) Run(ctx context.Context, state multistep.
 	}
 
 	acgNo, err := s.CreateAccessControlGroup()
-	s.Say(fmt.Sprintf("Creating temporary ACG [%s]", acgNo))
+	s.Say("Creating temporary ACG " + acgNo)
 	if err != nil || len(acgNo) == 0 {
 		err := fmt.Errorf("couldn't create ACG for VPC: %s", err)
 		state.Put("error", err)
@@ -174,7 +174,7 @@ func (s *StepCreateAccessControlGroup) Run(ctx context.Context, state multistep.
 
 	s.createdAcgNo = acgNo
 
-	s.Say(fmt.Sprintf("Creating temporary rules ACG [%s]", acgNo))
+	s.Say("Creating temporary rules ACG " + acgNo)
 	err = s.AddAccessControlGroupRule(acgNo)
 	if err != nil {
 		err := fmt.Errorf("couldn't create ACG rules for SSH or winrm: %s", err)

--- a/builder/ncloud/step_create_block_storage_instance.go
+++ b/builder/ncloud/step_create_block_storage_instance.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"time"
 
@@ -68,7 +67,7 @@ func (s *StepCreateBlockStorage) createClassicBlockStorage(serverInstanceNo stri
 	}
 
 	blockStorageInstance := resp.BlockStorageInstanceList[0]
-	s.Say(fmt.Sprintf("Block Storage Instance is creating. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
+	s.Say("Block Storage Instance is creating. InstanceNo is " + *blockStorageInstance.BlockStorageInstanceNo)
 
 	respInfo, _ := json.Marshal(resp)
 	log.Printf("createClassicBlockStorage response=%s", respInfo)
@@ -77,7 +76,7 @@ func (s *StepCreateBlockStorage) createClassicBlockStorage(serverInstanceNo stri
 		return nil, errors.New("TIMEOUT : Block Storage instance status is not attached")
 	}
 
-	s.Say(fmt.Sprintf("Block Storage Instance is created. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
+	s.Say("Block Storage Instance is created. InstanceNo is " + *blockStorageInstance.BlockStorageInstanceNo)
 
 	return blockStorageInstance.BlockStorageInstanceNo, nil
 }
@@ -98,7 +97,7 @@ func (s *StepCreateBlockStorage) createVpcBlockStorage(serverInstanceNo string) 
 	}
 
 	blockStorageInstance := resp.BlockStorageInstanceList[0]
-	s.Say(fmt.Sprintf("Block Storage Instance is creating. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
+	s.Say("Block Storage Instance is creating. InstanceNo is " + *blockStorageInstance.BlockStorageInstanceNo)
 
 	respInfo, _ := json.Marshal(resp)
 	log.Printf("createVpcBlockStorage response=%s", respInfo)
@@ -107,7 +106,7 @@ func (s *StepCreateBlockStorage) createVpcBlockStorage(serverInstanceNo string) 
 		return nil, errors.New("TIMEOUT : Block Storage instance status is not attached")
 	}
 
-	s.Say(fmt.Sprintf("Block Storage Instance is created. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
+	s.Say("Block Storage Instance is created. InstanceNo is " + *blockStorageInstance.BlockStorageInstanceNo)
 
 	return blockStorageInstance.BlockStorageInstanceNo, nil
 }
@@ -175,7 +174,7 @@ func (s *StepCreateBlockStorage) Cleanup(state multistep.StateBag) {
 			return
 		}
 
-		s.Say(fmt.Sprintf("Block Storage Instance is deleted. Block Storage InstanceNo is %s", blockStorageInstanceNo.(string)))
+		s.Say("Block Storage Instance is deleted. Block Storage InstanceNo is " + blockStorageInstanceNo.(string))
 
 		if err := s.WaiterBlockStorageStatus(s.Conn, blockStorageInstanceNo.(*string), BlockStorageStatusDetached, time.Minute); err != nil {
 			s.Say("TIMEOUT : Block Storage instance status is not deattached")

--- a/builder/ncloud/step_create_block_storage_instance.go
+++ b/builder/ncloud/step_create_block_storage_instance.go
@@ -5,6 +5,7 @@ package ncloud
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -67,11 +68,16 @@ func (s *StepCreateBlockStorage) createClassicBlockStorage(serverInstanceNo stri
 	}
 
 	blockStorageInstance := resp.BlockStorageInstanceList[0]
-	log.Println("Block Storage Instance information : ", blockStorageInstance.BlockStorageInstanceNo)
+	s.Say(fmt.Sprintf("Block Storage Instance is creating. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
+
+	respInfo, _ := json.Marshal(resp)
+	log.Printf("createClassicBlockStorage response=%s", respInfo)
 
 	if err := waiterClassicBlockStorageStatus(s.Conn, blockStorageInstance.BlockStorageInstanceNo, BlockStorageStatusAttached, 10*time.Minute); err != nil {
 		return nil, errors.New("TIMEOUT : Block Storage instance status is not attached")
 	}
+
+	s.Say(fmt.Sprintf("Block Storage Instance is created. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
 
 	return blockStorageInstance.BlockStorageInstanceNo, nil
 }
@@ -92,11 +98,16 @@ func (s *StepCreateBlockStorage) createVpcBlockStorage(serverInstanceNo string) 
 	}
 
 	blockStorageInstance := resp.BlockStorageInstanceList[0]
-	log.Println("Block Storage Instance information : ", blockStorageInstance.BlockStorageInstanceNo)
+	s.Say(fmt.Sprintf("Block Storage Instance is creating. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
+
+	respInfo, _ := json.Marshal(resp)
+	log.Printf("createVpcBlockStorage response=%s", respInfo)
 
 	if err := s.WaiterBlockStorageStatus(s.Conn, blockStorageInstance.BlockStorageInstanceNo, BlockStorageStatusAttached, 10*time.Minute); err != nil {
 		return nil, errors.New("TIMEOUT : Block Storage instance status is not attached")
 	}
+
+	s.Say(fmt.Sprintf("Block Storage Instance is created. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
 
 	return blockStorageInstance.BlockStorageInstanceNo, nil
 }

--- a/builder/ncloud/step_create_init_script.go
+++ b/builder/ncloud/step_create_init_script.go
@@ -102,7 +102,7 @@ func (s *StepCreateInitScript) Run(ctx context.Context, state multistep.StateBag
 	initScriptNo, err := s.CreateInitScript()
 	if err == nil && initScriptNo != "" {
 		state.Put("init_script_no", initScriptNo)
-		s.Say(fmt.Sprintf("Init script[%s] is created", initScriptNo))
+		s.Say("Init script[" + initScriptNo + "] is created")
 	}
 
 	return processStepResult(err, s.Error, state)

--- a/builder/ncloud/step_create_login_key.go
+++ b/builder/ncloud/step_create_login_key.go
@@ -99,7 +99,7 @@ func (s *StepCreateLoginKey) Run(ctx context.Context, state multistep.StateBag) 
 	loginKey, err := s.CreateLoginKey()
 	if err == nil {
 		state.Put("login_key", loginKey)
-		s.Say(fmt.Sprintf("Login Key[%s] is created", loginKey.KeyName))
+		s.Say("Login Key[" + loginKey.KeyName + "] is created")
 	}
 
 	return processStepResult(err, s.Error, state)

--- a/builder/ncloud/step_create_public_ip_instance.go
+++ b/builder/ncloud/step_create_public_ip_instance.go
@@ -190,7 +190,7 @@ func (s *StepCreatePublicIP) createClassicPublicIP(serverInstanceNo string) (*se
 
 	publicIPInstance := publicIPInstanceList.PublicIpInstanceList[0]
 	publicIP := publicIPInstance.PublicIp
-	s.Say(fmt.Sprintf("Public IP Instance [%s:%s] is created", *publicIPInstance.PublicIpInstanceNo, *publicIP))
+	s.Say("Public IP Instance [" + *publicIPInstance.PublicIpInstanceNo + ":" + *publicIP + "] is created")
 
 	err = s.WaiterAssociatePublicIPToServerInstance(serverInstanceNo, *publicIP)
 	if err != nil {
@@ -213,7 +213,7 @@ func (s *StepCreatePublicIP) createVpcPublicIP(serverInstanceNo string) (*server
 
 	publicIPInstance := publicIPInstanceList.PublicIpInstanceList[0]
 	publicIP := publicIPInstance.PublicIp
-	s.Say(fmt.Sprintf("Public IP Instance [%s:%s] is created", *publicIPInstance.PublicIpInstanceNo, *publicIP))
+	s.Say("Public IP Instance [" + *publicIPInstance.PublicIpInstanceNo + ":" + *publicIP + "] is created")
 
 	err = s.WaiterAssociatePublicIPToServerInstance(serverInstanceNo, *publicIP)
 	if err != nil {

--- a/builder/ncloud/step_create_server_image.go
+++ b/builder/ncloud/step_create_server_image.go
@@ -6,7 +6,6 @@ package ncloud
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
@@ -63,13 +62,13 @@ func (s *StepCreateServerImage) createClassicServerImage(serverInstanceNo string
 
 	serverImage := memberServerImageList.MemberServerImageList[0]
 
-	s.Say(fmt.Sprintf("Server Image[%s:%s] is creating...", *serverImage.MemberServerImageName, *serverImage.MemberServerImageNo))
+	s.Say("Server Image[" + *serverImage.MemberServerImageName + ":" + *serverImage.MemberServerImageNo + "] is creating...")
 
 	if err := waiterClassicMemberServerImageStatus(s.Conn, *serverImage.MemberServerImageNo, ServerImageStatusCreated, 6*time.Hour); err != nil {
 		return nil, errors.New("TIMEOUT : Server Image is not created")
 	}
 
-	s.Say(fmt.Sprintf("Server Image[%s:%s] is created", *serverImage.MemberServerImageName, *serverImage.MemberServerImageNo))
+	s.Say("Server Image[" + *serverImage.MemberServerImageName + ":" + *serverImage.MemberServerImageNo + "] is created")
 
 	return serverImage, nil
 }
@@ -93,13 +92,13 @@ func (s *StepCreateServerImage) createVpcServerImage(serverInstanceNo string) (*
 
 	serverImage := memberServerImageList.MemberServerImageInstanceList[0]
 
-	s.Say(fmt.Sprintf("Server Image[%s:%s] is creating...", *serverImage.MemberServerImageName, *serverImage.MemberServerImageInstanceNo))
+	s.Say("Server Image[" + *serverImage.MemberServerImageName + ":" + *serverImage.MemberServerImageInstanceNo + "] is creating...")
 
 	if err := waiterVpcMemberServerImageStatus(s.Conn, *serverImage.MemberServerImageInstanceNo, ServerImageStatusCreated, 6*time.Hour); err != nil {
 		return nil, errors.New("TIMEOUT : Server Image is not created")
 	}
 
-	s.Say(fmt.Sprintf("Server Image[%s:%s] is created", *serverImage.MemberServerImageName, *serverImage.MemberServerImageInstanceNo))
+	s.Say("Server Image[" + *serverImage.MemberServerImageName + ":" + *serverImage.MemberServerImageInstanceNo + "] is created")
 
 	result := &server.MemberServerImage{
 		MemberServerImageNo:   serverImage.MemberServerImageInstanceNo,

--- a/builder/ncloud/step_create_server_instance.go
+++ b/builder/ncloud/step_create_server_instance.go
@@ -94,7 +94,7 @@ func (s *StepCreateServerInstance) createClassicServerInstance(loginKeyName stri
 	}
 
 	s.serverInstanceNo = *serverInstanceList.ServerInstanceList[0].ServerInstanceNo
-	s.Say(fmt.Sprintf("Server Instance is creating. Server InstanceNo is %s", s.serverInstanceNo))
+	s.Say("Server Instance is creating. Server InstanceNo is " + s.serverInstanceNo)
 
 	resp, _ := json.Marshal(serverInstanceList)
 	log.Printf("createClassicServerInstance response=%s", resp)
@@ -103,7 +103,7 @@ func (s *StepCreateServerInstance) createClassicServerInstance(loginKeyName stri
 		return "", errors.New("TIMEOUT : server instance status is not running")
 	}
 
-	s.Say(fmt.Sprintf("Server Instance is created. Server InstanceNo is %s", s.serverInstanceNo))
+	s.Say("Server Instance is created. Server InstanceNo is " + s.serverInstanceNo)
 
 	return s.serverInstanceNo, nil
 }
@@ -148,7 +148,7 @@ func (s *StepCreateServerInstance) createVpcServerInstance(loginKeyName string, 
 	}
 
 	s.serverInstanceNo = *serverInstanceList.ServerInstanceList[0].ServerInstanceNo
-	s.Say(fmt.Sprintf("Server Instance is creating. Server InstanceNo is %s", s.serverInstanceNo))
+	s.Say("Server Instance is creating. Server InstanceNo is " + s.serverInstanceNo)
 
 	resp, _ := json.Marshal(serverInstanceList)
 	log.Printf("createVpcServerInstance response=%s", resp)
@@ -157,7 +157,7 @@ func (s *StepCreateServerInstance) createVpcServerInstance(loginKeyName string, 
 		return "", errors.New("TIMEOUT : server instance status is not running")
 	}
 
-	s.Say(fmt.Sprintf("Server Instance is created. Server InstanceNo is %s", s.serverInstanceNo))
+	s.Say("Server Instance is created. Server InstanceNo is " + s.serverInstanceNo)
 
 	return s.serverInstanceNo, nil
 }

--- a/builder/ncloud/step_create_server_instance.go
+++ b/builder/ncloud/step_create_server_instance.go
@@ -5,6 +5,7 @@ package ncloud
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -94,7 +95,9 @@ func (s *StepCreateServerInstance) createClassicServerInstance(loginKeyName stri
 
 	s.serverInstanceNo = *serverInstanceList.ServerInstanceList[0].ServerInstanceNo
 	s.Say(fmt.Sprintf("Server Instance is creating. Server InstanceNo is %s", s.serverInstanceNo))
-	log.Println("Server Instance information : ", serverInstanceList.ServerInstanceList[0])
+
+	resp, _ := json.Marshal(serverInstanceList)
+	log.Printf("createClassicServerInstance response=%s", resp)
 
 	if err := s.WaiterServerInstanceStatus(s.Conn, s.serverInstanceNo, ServerInstanceStatusRunning, 30*time.Minute); err != nil {
 		return "", errors.New("TIMEOUT : server instance status is not running")
@@ -146,7 +149,9 @@ func (s *StepCreateServerInstance) createVpcServerInstance(loginKeyName string, 
 
 	s.serverInstanceNo = *serverInstanceList.ServerInstanceList[0].ServerInstanceNo
 	s.Say(fmt.Sprintf("Server Instance is creating. Server InstanceNo is %s", s.serverInstanceNo))
-	log.Println("Server Instance information : ", serverInstanceList.ServerInstanceList[0])
+
+	resp, _ := json.Marshal(serverInstanceList)
+	log.Printf("createVpcServerInstance response=%s", resp)
 
 	if err := s.WaiterServerInstanceStatus(s.Conn, s.serverInstanceNo, ServerInstanceStatusRunning, 30*time.Minute); err != nil {
 		return "", errors.New("TIMEOUT : server instance status is not running")

--- a/builder/ncloud/step_delete_block_storage_instance.go
+++ b/builder/ncloud/step_delete_block_storage_instance.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"time"
 
@@ -61,7 +60,7 @@ func (s *StepDeleteBlockStorage) getClassicBlockList(serverInstanceNo string) []
 	for _, blockStorageInstance := range blockStorageInstanceList.BlockStorageInstanceList {
 		if *blockStorageInstance.BlockStorageType.Code != "BASIC" {
 			instanceList = append(instanceList, blockStorageInstance.BlockStorageInstanceNo)
-			s.Say(fmt.Sprintf("Block Storage Instance is deleting. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
+			s.Say("Block Storage Instance is deleting. InstanceNo is " + *blockStorageInstance.BlockStorageInstanceNo)
 		}
 	}
 
@@ -87,7 +86,7 @@ func (s *StepDeleteBlockStorage) getVpcBlockList(serverInstanceNo string) []*str
 	for _, blockStorageInstance := range blockStorageInstanceList.BlockStorageInstanceList {
 		if *blockStorageInstance.BlockStorageType.Code != "BASIC" {
 			instanceList = append(instanceList, blockStorageInstance.BlockStorageInstanceNo)
-			s.Say(fmt.Sprintf("Block Storage Instance is deleting. InstanceNo is %s", *blockStorageInstance.BlockStorageInstanceNo))
+			s.Say("Block Storage Instance is deleting. InstanceNo is " + *blockStorageInstance.BlockStorageInstanceNo)
 		}
 	}
 
@@ -115,7 +114,7 @@ func (s *StepDeleteBlockStorage) deleteClassicBlockStorage(serverInstanceNo stri
 		return errors.New("TIMEOUT : Block Storage instance status is not deattached")
 	}
 
-	s.Say(fmt.Sprintf("Block Storage Instance is deleted"))
+	s.Say("Block Storage Instance is deleted")
 
 	return nil
 }
@@ -141,7 +140,7 @@ func (s *StepDeleteBlockStorage) deleteVpcBlockStorage(serverInstanceNo string) 
 		return errors.New("TIMEOUT : Block Storage instance status is not deattached")
 	}
 
-	s.Say(fmt.Sprintf("Block Storage Instance is deleted"))
+	s.Say("Block Storage Instance is deleted")
 
 	return nil
 }

--- a/builder/ncloud/step_get_rootpassword.go
+++ b/builder/ncloud/step_get_rootpassword.go
@@ -5,7 +5,6 @@ package ncloud
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
@@ -49,7 +48,7 @@ func (s *StepGetRootPassword) getClassicRootPassword(serverInstanceNo string, pr
 		return "", err
 	}
 
-	s.Say(fmt.Sprintf("Root password is %s", *rootPassword.RootPassword))
+	s.Say("Root password is " + *rootPassword.RootPassword)
 
 	return *rootPassword.RootPassword, nil
 }
@@ -66,7 +65,7 @@ func (s *StepGetRootPassword) getVpcRootPassword(serverInstanceNo string, privat
 		return "", err
 	}
 
-	s.Say(fmt.Sprintf("Root password is %s", *rootPassword.RootPassword))
+	s.Say("Root password is " + *rootPassword.RootPassword)
 
 	return *rootPassword.RootPassword, nil
 }

--- a/builder/ncloud/step_stop_server_instance.go
+++ b/builder/ncloud/step_stop_server_instance.go
@@ -5,7 +5,6 @@ package ncloud
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
@@ -52,13 +51,13 @@ func (s *StepStopServerInstance) stopClassicServerInstance(serverInstanceNo stri
 		return err
 	}
 
-	s.Say(fmt.Sprintf("Server Instance is stopping. Server InstanceNo is %s", *serverInstanceList.ServerInstanceList[0].ServerInstanceNo))
+	s.Say("Server Instance is stopping. Server InstanceNo is " + *serverInstanceList.ServerInstanceList[0].ServerInstanceNo)
 
 	if err := s.WaiterServerInstanceStatus(s.Conn, serverInstanceNo, ServerInstanceStatusStopped, 5*time.Minute); err != nil {
 		return err
 	}
 
-	s.Say(fmt.Sprintf("Server Instance stopped. Server InstanceNo is %s", *serverInstanceList.ServerInstanceList[0].ServerInstanceNo))
+	s.Say("Server Instance stopped. Server InstanceNo is " + *serverInstanceList.ServerInstanceList[0].ServerInstanceNo)
 
 	return nil
 }
@@ -74,13 +73,13 @@ func (s *StepStopServerInstance) stopVpcServerInstance(serverInstanceNo string) 
 		return err
 	}
 
-	s.Say(fmt.Sprintf("Server Instance is stopping. Server InstanceNo is %s", *serverInstanceList.ServerInstanceList[0].ServerInstanceNo))
+	s.Say("Server Instance is stopping. Server InstanceNo is " + *serverInstanceList.ServerInstanceList[0].ServerInstanceNo)
 
 	if err := s.WaiterServerInstanceStatus(s.Conn, serverInstanceNo, ServerInstanceStatusStopped, 5*time.Minute); err != nil {
 		return err
 	}
 
-	s.Say(fmt.Sprintf("Server Instance stopped. Server InstanceNo is %s", *serverInstanceList.ServerInstanceList[0].ServerInstanceNo))
+	s.Say("Server Instance stopped. Server InstanceNo is " + *serverInstanceList.ServerInstanceList[0].ServerInstanceNo)
 
 	return nil
 }

--- a/builder/ncloud/step_terminate_server_instance.go
+++ b/builder/ncloud/step_terminate_server_instance.go
@@ -6,7 +6,6 @@ package ncloud
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"time"
 
@@ -50,7 +49,7 @@ func (s *StepTerminateServerInstance) terminateClassicServerInstance(serverInsta
 	if err != nil {
 		return err
 	}
-	s.Say(fmt.Sprintf("Server Instance is terminating. Server InstanceNo is %s", serverInstanceNo))
+	s.Say("Server Instance is terminating. Server InstanceNo is " + serverInstanceNo)
 
 	c1 := make(chan error, 1)
 
@@ -76,7 +75,7 @@ func (s *StepTerminateServerInstance) terminateClassicServerInstance(serverInsta
 
 	select {
 	case res := <-c1:
-		s.Say(fmt.Sprintf("Server Instance terminated. Server InstanceNo is %s", serverInstanceNo))
+		s.Say("Server Instance terminated. Server InstanceNo is " + serverInstanceNo)
 		return res
 	case <-time.After(time.Second * 60):
 		return errors.New("TIMEOUT : Can't terminate server instance")
@@ -92,7 +91,7 @@ func (s *StepTerminateServerInstance) terminateVpcServerInstance(serverInstanceN
 	if err != nil {
 		return err
 	}
-	s.Say(fmt.Sprintf("Server Instance is terminating. Server InstanceNo is %s", serverInstanceNo))
+	s.Say("Server Instance is terminating. Server InstanceNo is " + serverInstanceNo)
 
 	c1 := make(chan error, 1)
 
@@ -119,7 +118,7 @@ func (s *StepTerminateServerInstance) terminateVpcServerInstance(serverInstanceN
 
 	select {
 	case res := <-c1:
-		s.Say(fmt.Sprintf("Server Instance terminated. Server InstanceNo is %s", serverInstanceNo))
+		s.Say("Server Instance terminated. Server InstanceNo is " + serverInstanceNo)
 		return res
 	case <-time.After(time.Second * 120):
 		return errors.New("TIMEOUT : Can't terminate server instance")

--- a/builder/ncloud/step_validate_template.go
+++ b/builder/ncloud/step_validate_template.go
@@ -504,7 +504,7 @@ func (s *StepValidateTemplate) validateTemplate() error {
 		return err
 	}
 
-	s.Say(fmt.Sprintf("vpc: %s, subnet: %s", s.Config.VpcNo, s.Config.SubnetNo))
+	s.Say("vpc: " + s.Config.VpcNo + ", subnet: " + s.Config.SubnetNo)
 	// Validate server_product_code
 	return s.validateServerProductCode()
 }

--- a/builder/ncloud/waiter_block_storage_instance.go
+++ b/builder/ncloud/waiter_block_storage_instance.go
@@ -41,7 +41,7 @@ func waiterClassicBlockStorageStatus(conn *NcloudAPIClient, blockStorageInstance
 				return
 			}
 
-			log.Println(blockStorageInstance)
+			log.Printf("Status of blockStorageInstanceNo [%s] is %s\n", *blockStorageInstanceNo, *code)
 			time.Sleep(time.Second * 5)
 		}
 	}()
@@ -83,7 +83,7 @@ func waiterVpcBlockStorageStatus(conn *NcloudAPIClient, blockStorageInstanceNo *
 				return
 			}
 
-			log.Println(blockStorageInstance)
+			log.Printf("Status of blockStorageInstanceNo [%s] is %s\n", *blockStorageInstanceNo, *code)
 			time.Sleep(time.Second * 5)
 		}
 	}()


### PR DESCRIPTION
### Description
- Minor, but fixes logs that output pointer addresses
```
[AS-IS]
==> ncloud.test-tomcat: Delete Block Storage Instance
==> ncloud.test-tomcat: Block Storage Instance is deleted. Block Storage Instance List is [0x140003f3380]
[TO-BE]
==> ncloud.test-tomcat: Delete Block Storage Instance
==> ncloud.test-tomcat: Block Storage Instance is deleting. InstanceNo is 20320001
==> ncloud.test-tomcat: Block Storage Instance is deleting. InstanceNo is 20320002
==> ncloud.test-tomcat: Block Storage Instance is deleted
```
- FIX golangci-lint
```
Error: S1039: unnecessary use of fmt.Sprintf (gosimple)

[AS-IS]
s.Say(fmt.Sprintf("Creating temporary ACG [%s]", acgNo))
[TO-BE]
s.Say("Creating temporary ACG " + acgNo)
```

